### PR TITLE
Added the ability to parse column definitions from tables with no records

### DIFF
--- a/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/HANAMetadataParser.scala
+++ b/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/HANAMetadataParser.scala
@@ -35,6 +35,14 @@ class HANAMetadataParser(_connection: Connection) extends DatabaseMetadataParser
        |LIMIT 1
      """.stripMargin
 
+  override def joinedSingleRecordQuery(schema: String, table: String): String =
+    s"""
+       |SELECT t.*
+       |FROM SYS.DUMMY AS d
+       |  LEFT OUTER JOIN $schema.$table AS t ON 1=1
+       |LIMIT 1
+     """.stripMargin
+
   override def listTablesStatement(schema: String) =
     s"""
        |SELECT TABLE_NAME
@@ -63,4 +71,5 @@ class HANAMetadataParser(_connection: Connection) extends DatabaseMetadataParser
        |WHERE SCHEMA_NAME = '$schema' AND TABLE_NAME = '$table'
        |ORDER BY POSITION
      """.stripMargin
+
 }

--- a/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/MsSQLMetadataParser.scala
+++ b/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/MsSQLMetadataParser.scala
@@ -42,6 +42,13 @@ class MsSQLMetadataParser(_connection: Connection) extends DatabaseMetadataParse
        |FROM \"$table\"
      """.stripMargin
 
+  override def joinedSingleRecordQuery(schema: String, table: String): String =
+    s"""
+       |SELECT TOP 1 t.*
+       |FROM INFORMATION_SCHEMA.TABLES AS d
+       |  LEFT OUTER JOIN \"$schema\".\"$table\" AS t ON 1=1
+     """.stripMargin
+
   override def listViewsStatement(schema: String) =
     s"""
        |SELECT TABLE_NAME
@@ -107,4 +114,5 @@ class MsSQLMetadataParser(_connection: Connection) extends DatabaseMetadataParse
        |  AND schemas.name = '$schema'
        |ORDER BY objects.name, columns.column_id
      """.stripMargin
+
 }

--- a/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/MySQLMetadataParser.scala
+++ b/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/MySQLMetadataParser.scala
@@ -33,6 +33,14 @@ class MySQLMetadataParser(_connection: Connection) extends DatabaseMetadataParse
        |LIMIT 1
      """.stripMargin
 
+  override def joinedSingleRecordQuery(schema: String, table: String): String =
+    s"""
+       |SELECT t.*
+       |FROM INFORMATION_SCHEMA.TABLES AS d
+       |  LEFT OUTER JOIN $schema.$table AS t ON 1=1
+       |LIMIT 1
+     """.stripMargin
+
   override def listTablesStatement(schema: String) =
     s"""
        |SELECT TABLE_NAME
@@ -60,4 +68,5 @@ class MySQLMetadataParser(_connection: Connection) extends DatabaseMetadataParse
        |FROM INFORMATION_SCHEMA.COLUMNS
        |WHERE TABLE_SCHEMA = '$schema' AND TABLE_NAME = '$table'
      """.stripMargin
+
 }

--- a/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/OracleMetadataParser.scala
+++ b/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/OracleMetadataParser.scala
@@ -33,6 +33,14 @@ class OracleMetadataParser(_connection: Connection) extends DatabaseMetadataPars
        |WHERE ROWNUM = 1
      """.stripMargin
 
+  override def joinedSingleRecordQuery(schema: String, table: String): String =
+    s"""
+       |SELECT t.*
+       |FROM SYS.DUAL AS d
+       |  LEFT OUTER JOIN $schema.$table AS t ON 1=1
+       |WHERE ROWNUM = 1
+     """.stripMargin
+
   override def listTablesStatement(schema: String) =
     s"""
        |SELECT table_name

--- a/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/TeradataMetadataParser.scala
+++ b/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/TeradataMetadataParser.scala
@@ -32,6 +32,13 @@ class TeradataMetadataParser(_connection: Connection) extends DatabaseMetadataPa
        |FROM $schema.$table
      """.stripMargin
 
+  override def joinedSingleRecordQuery(schema: String, table: String): String =
+    s"""
+       |SELECT TOP 1 t.*
+       |FROM dbc.tables AS d
+       |  LEFT OUTER JOIN $schema.$table AS t ON 1 = 1
+     """.stripMargin
+
   override def listTablesStatement(schema: String) =
     s"""
        |SELECT tablename FROM dbc.tables WHERE tablekind = 'T' and databasename='$schema'
@@ -55,4 +62,5 @@ class TeradataMetadataParser(_connection: Connection) extends DatabaseMetadataPa
        |FROM DBC.Columns
        |WHERE DatabaseName = '$schema' AND TableName = '$table'
      """.stripMargin
+
 }

--- a/src/main/resources/environment.yml
+++ b/src/main/resources/environment.yml
@@ -4,7 +4,7 @@ databaseType: mysql # Database type must be mysql, oracle, mssql, hana, or terad
 schema: employees # Database schema to ingest
 jdbcUrl: "jdbc:mysql://localhost:3306/employees" # JDBC Url for connecting to database
 username: employee # Database user name
-objectType: view # Database object type to be ingested must be either table or view
+objectType: table # Database object type to be ingested must be either table or view
 # tables: # Optionally add a whitelisting of tables to ingest
 #   - employee
 metadata: # Metadata map to be applied to every table's tblproperties. https://www.cloudera.com/documentation/enterprise/latest/topics/impala_create_table.html


### PR DESCRIPTION
If a table has no records then a second attempt to get column meta data will be used.  The second attempt will join to a SYS or INFORMATION_SCHEMA table to LEFT OUTER JOIN to the empty table.