### PR TITLE
Removed the 'as' when created the table alias for the single record q…

### DIFF
--- a/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/OracleMetadataParser.scala
+++ b/jdbc-metadata/src/main/scala/io/phdata/pipeforge/jdbc/OracleMetadataParser.scala
@@ -36,8 +36,8 @@ class OracleMetadataParser(_connection: Connection) extends DatabaseMetadataPars
   override def joinedSingleRecordQuery(schema: String, table: String): String =
     s"""
        |SELECT t.*
-       |FROM SYS.DUAL AS d
-       |  LEFT OUTER JOIN $schema.$table AS t ON 1=1
+       |FROM SYS.DUAL d
+       |  LEFT OUTER JOIN $schema.$table t ON 1=1
        |WHERE ROWNUM = 1
      """.stripMargin
 


### PR DESCRIPTION
Oracle was returning the `query not properly ended` message when AS was included in the single record query. I removed `AS` and tested and Oracle now does fine this query.